### PR TITLE
remove username from .zshrc fix

### DIFF
--- a/mkdocs/docs/troubleshooting.md
+++ b/mkdocs/docs/troubleshooting.md
@@ -5,8 +5,7 @@
 When using https://ohmyz.sh/ there is currently an issue with using Global Tools in .net core 2.1 and MacOS. For the global tools to work you need to edit the `.zshrc` file and add:
 
 ``` bash
-path+=('/Users/YOUR_USER_NAME/.dotnet/tools')
-export PATH
+export PATH=$HOME/.dotnet/tools:$PATH
 ```
 
 The normal `~/.dotnet/tools` is not recognized by `zsh`.


### PR DESCRIPTION
ZSH uses `$HOME` to reference the profile directory. Tested on ZSH 5.3.